### PR TITLE
chore: add go toolchain directive for 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/sebrandon1/compliance-operator-dashboard
 
-go 1.26.2
+go 1.26
+
+toolchain go1.26.2
 
 require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674


### PR DESCRIPTION
## Summary

Set `go 1.26` as the minimum language version with `toolchain go1.26.2` in go.mod. This allows developers with `GOTOOLCHAIN=auto` (the default) to automatically download Go 1.26.2 if they have an older version installed.

## Related PRs

- sebrandon1/testapp#7
- sebrandon1/yaml-to-readme#129
- sebrandon1/go-dci#108
- sebrandon1/go-enphase#16
- sebrandon1/go-quay#84
- sebrandon1/go-skylight#34
- sebrandon1/jiracrawler#79
- sebrandon1/ztp-dashboard#49
- sebrandon1/mirrorbot#33
- sebrandon1/skylight-bridge#9