### PR TITLE
fix: bump toolchain to go1.26.5 to resolve govulncheck CVE GO-2026-5856

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/sebrandon1/compliance-operator-dashboard
 
 go 1.26.0
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674


### PR DESCRIPTION
## Summary
- Bumps `toolchain` directive in `go.mod` to `go1.26.5`
- Resolves govulncheck finding GO-2026-5856: Encrypted Client Hello privacy leak in `crypto/tls`, fixed in `go1.26.5`

## Test plan
- [ ] CI govulncheck passes